### PR TITLE
:bug: Fix ghost point direction

### DIFF
--- a/src/format/LemLibFormatV0_4.tsx
+++ b/src/format/LemLibFormatV0_4.tsx
@@ -300,7 +300,7 @@ export class LemLibFormatV0_4 implements Format {
       rtn += `${uc.fromAtoB(point.x).toUser()}, ${uc.fromAtoB(point.y).toUser()}, ${point.speed.toUser()}\n`;
     }
 
-    if (points.length > 1) {
+    if (points.length > 2) {
       /*
       Here is the original code of how the ghost point is calculated:
 

--- a/src/format/LemLibFormatV0_4.tsx
+++ b/src/format/LemLibFormatV0_4.tsx
@@ -314,8 +314,9 @@ export class LemLibFormatV0_4 implements Format {
       Notice that the variable "lastControl" is not the last control point, but the second last control point.
       This implementation is different from the original implementation by using the last point and the second last point.
       */
-      const last2 = points[points.length - 2]; // second last point, last point by the calculation
-      const last1 = points[points.length - 1]; // last point, also the last control point
+      // ALGO: use second and third last points, since first and second last point are always identical
+      const last2 = points[points.length - 3]; // third last point, last point by the calculation
+      const last1 = points[points.length - 2]; // second last point, also the last control point
       // ALGO: The 20 inches constant is a constant value in the original LemLib-Path-Gen implementation.
       const ghostPoint = last2.interpolate(last1, last2.distance(last1) + uc.fromBtoA(20));
       rtn += `${uc.fromAtoB(ghostPoint.x).toUser()}, ${uc.fromAtoB(ghostPoint.y).toUser()}, 0\n`;

--- a/src/format/LemLibFormatV0_4.tsx
+++ b/src/format/LemLibFormatV0_4.tsx
@@ -300,27 +300,27 @@ export class LemLibFormatV0_4 implements Format {
       rtn += `${uc.fromAtoB(point.x).toUser()}, ${uc.fromAtoB(point.y).toUser()}, ${point.speed.toUser()}\n`;
     }
 
-    if (points.length > 2) {
-      /*
-      Here is the original code of how the ghost point is calculated:
+    if (points.length < 3) throw new Error("The path is too short to export");
 
-      ```cpp
-      // create a "ghost point" at the end of the path to make stopping nicer
-      const lastPoint = path.points[path.points.length-1];
-      const lastControl = path.segments[path.segments.length-1].p2;
-      const ghostPoint = Vector.interpolate(Vector.distance(lastControl, lastPoint) + 20, lastControl, lastPoint);
-      ```
+    /*
+    Here is the original code of how the ghost point is calculated:
 
-      Notice that the variable "lastControl" is not the last control point, but the second last control point.
-      This implementation is different from the original implementation by using the last point and the second last point.
-      */
-      // ALGO: use second and third last points, since first and second last point are always identical
-      const last2 = points[points.length - 3]; // third last point, last point by the calculation
-      const last1 = points[points.length - 2]; // second last point, also the last control point
-      // ALGO: The 20 inches constant is a constant value in the original LemLib-Path-Gen implementation.
-      const ghostPoint = last2.interpolate(last1, last2.distance(last1) + uc.fromBtoA(20));
-      rtn += `${uc.fromAtoB(ghostPoint.x).toUser()}, ${uc.fromAtoB(ghostPoint.y).toUser()}, 0\n`;
-    }
+    ```cpp
+    // create a "ghost point" at the end of the path to make stopping nicer
+    const lastPoint = path.points[path.points.length-1];
+    const lastControl = path.segments[path.segments.length-1].p2;
+    const ghostPoint = Vector.interpolate(Vector.distance(lastControl, lastPoint) + 20, lastControl, lastPoint);
+    ```
+
+    Notice that the variable "lastControl" is not the last control point, but the second last control point.
+    This implementation is different from the original implementation by using the last point and the second last point.
+    */
+    // ALGO: use second and third last points, since first and second last point are always identical
+    const last2 = points[points.length - 3]; // third last point, last point by the calculation
+    const last1 = points[points.length - 2]; // second last point, also the last control point
+    // ALGO: The 20 inches constant is a constant value in the original LemLib-Path-Gen implementation.
+    const ghostPoint = last2.interpolate(last1, last2.distance(last1) + uc.fromBtoA(20));
+    rtn += `${uc.fromAtoB(ghostPoint.x).toUser()}, ${uc.fromAtoB(ghostPoint.y).toUser()}, 0\n`;
 
     rtn += `endData\n`;
     rtn += `${(path.pc as PathConfigImpl).maxDecelerationRate}\n`;


### PR DESCRIPTION
### Overview
Fixed ghost point direction

### Previous Behavior
The ghost point is always offset 20 inches in the positive x direction, ignoring the direction of the path

### New Behavior
The ghost point now follows the direction of the path, and still has a magnitude of 20 inches

### Changes
- Use second and third last path points to determine direction instead of first and second last points, as the first and second last points are always the same.
- Change the path length check in the ghost point calculations from 1 to 2

### Tests:
- [X] Path download successful
- [X] Path reading successful
- [X] Ghost point confirmed through manual calculation