### PR TITLE
Added Boomerang code 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "vscode.typescript-language-features"
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "path.jerryio",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/src/format/Format.tsx
+++ b/src/format/Format.tsx
@@ -84,7 +84,12 @@ export function getAllFormats(): Format[] {
       new LemLibOdomGeneratorFormatV0_4()
     ],
     ...(isExperimentalFeaturesEnabled()
-      ? [new LemLibFormatV1_0(), new RigidCodeGenFormatV0_1(), new MoveToPointCodeGenFormatV0_1(), new xVecLibBoomerangFormatV0_1()]
+      ? [
+          new LemLibFormatV1_0(),
+          new RigidCodeGenFormatV0_1(),
+          new MoveToPointCodeGenFormatV0_1(),
+          new xVecLibBoomerangFormatV0_1()
+        ]
       : []),
     ...[new PathDotJerryioFormatV0_1()]
   ];

--- a/src/format/Format.tsx
+++ b/src/format/Format.tsx
@@ -11,6 +11,7 @@ import { LemLibFormatV1_0 } from "./LemLibFormatV1_0";
 import { isExperimentalFeaturesEnabled } from "@core/Preferences";
 import { RigidCodeGenFormatV0_1 } from "./RigidCodeGenFormatV0_1";
 import { MoveToPointCodeGenFormatV0_1 } from "./MoveToPointCodeGenFormatV0_1";
+import { xVecLibBoomerangFormatV0_1 } from "./xVecLibBoomerangFormatV0_1";
 
 export interface Format {
   isInit: boolean;
@@ -83,7 +84,7 @@ export function getAllFormats(): Format[] {
       new LemLibOdomGeneratorFormatV0_4()
     ],
     ...(isExperimentalFeaturesEnabled()
-      ? [new LemLibFormatV1_0(), new RigidCodeGenFormatV0_1(), new MoveToPointCodeGenFormatV0_1()]
+      ? [new LemLibFormatV1_0(), new RigidCodeGenFormatV0_1(), new MoveToPointCodeGenFormatV0_1(), new xVecLibBoomerangFormatV0_1()]
       : []),
     ...[new PathDotJerryioFormatV0_1()]
   ];

--- a/src/format/xVecLibBoomerangFormatV0_1.tsx
+++ b/src/format/xVecLibBoomerangFormatV0_1.tsx
@@ -1,0 +1,298 @@
+import { makeAutoObservable, action } from "mobx";
+import { MainApp, getAppStores } from "@core/MainApp";
+import { EditableNumberRange, IS_MAC_OS, ValidateNumber, getMacHotKeyString, makeId } from "@core/Util";
+import { BentRateApplicationDirection, Path, Segment, Vector } from "@core/Path";
+import { UnitOfLength, UnitConverter, Quantity } from "@core/Unit";
+import { GeneralConfig, PathConfig, convertFormat, initGeneralConfig } from "./Config";
+import { Format, importPDJDataFromTextFile } from "./Format";
+import { Exclude, Expose, Type } from "class-transformer";
+import { IsBoolean, IsObject, IsPositive, IsString, MinLength, ValidateNested } from "class-validator";
+import { PointCalculationResult, getPathPoints, getDiscretePoints, fromDegreeToRadian } from "@core/Calculation";
+import { FieldImageOriginType, FieldImageSignatureAndOrigin, getDefaultBuiltInFieldImage } from "@core/Asset";
+import { UpdateProperties } from "@core/Command";
+import { ObserverInput } from "@app/component.blocks/ObserverInput";
+import { Box, Button, Typography } from "@mui/material";
+import { euclideanRotation } from "@core/Coordinate";
+import { CodePointBuffer, Int } from "../token/Tokens";
+import { observer } from "mobx-react-lite";
+import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from "@app/Notice";
+import { Logger } from "@core/Logger";
+import { getEnableOnNonTextInputFieldsHotkeysOptions, useCustomHotkeys } from "@core/Hook";
+import { ObserverCheckbox } from "@app/component.blocks/ObserverCheckbox";
+
+const logger = Logger("xVecLib Boomerang v0.1.0 (inch)");
+
+const GeneralConfigPanel = observer((props: { config: GeneralConfigImpl }) => {
+  const { config } = props;
+
+  const { app, confirmation, modals } = getAppStores();
+
+  const isUsingEditor = !confirmation.isOpen && !modals.isOpen;
+
+  const onCopyCode = action(() => {
+    try {
+      const code = config.format.exportCode();
+
+      navigator.clipboard.writeText(code);
+
+      enqueueSuccessSnackbar(logger, "Copied");
+    } catch (e) {
+      enqueueErrorSnackbar(logger, e);
+    }
+  });
+
+  useCustomHotkeys("Shift+Mod+C", onCopyCode, getEnableOnNonTextInputFieldsHotkeysOptions(isUsingEditor));
+
+  const hotkey = IS_MAC_OS ? getMacHotKeyString("Shift+Mod+C") : "Shift+Ctrl+C";
+
+  return (
+    <>
+      <Box className="Panel-Box">
+        <Typography sx={{ marginTop: "16px" }}>Export Settings</Typography>
+        <Box className="Panel-FlexBox">
+          <ObserverInput
+            label="Chassis Name"
+            getValue={() => config.chassisName}
+            setValue={(value: string) => {
+              app.history.execute(`Change chassis variable name`, new UpdateProperties(config, { chassisName: value }));
+            }}
+            isValidIntermediate={() => true}
+            isValidValue={(candidate: string) => candidate !== ""}
+            sx={{ marginTop: "16px" }}
+          />
+          <ObserverInput
+            label="Movement Timeout"
+            getValue={() => config.movementTimeout.toString()}
+            setValue={(value: string) => {
+              const parsedValue = parseInt(Int.parse(new CodePointBuffer(value))!.value);
+              app.history.execute(
+                `Change default movement timeout to ${parsedValue}`,
+                new UpdateProperties(config, { movementTimeout: parsedValue })
+              );
+            }}
+            isValidIntermediate={() => true}
+            isValidValue={(candidate: string) => Int.parse(new CodePointBuffer(candidate)) !== null}
+            sx={{ marginTop: "16px" }}
+            numeric
+          />
+        </Box>
+        <Box className="Panel-FlexBox">
+          <ObserverCheckbox
+            label="Use Relative Coordinates"
+            checked={config.relativeCoords}
+            onCheckedChange={value => {
+              app.history.execute(
+                `Set using relative coordinates to ${value}`,
+                new UpdateProperties(config, { relativeCoords: value })
+              );
+            }}
+          />
+        </Box>
+        <Box className="Panel-FlexBox" sx={{ marginTop: "32px" }}>
+          <Button variant="contained" title={`Copy Generated Code (${hotkey})`} onClick={onCopyCode}>
+            Copy Code
+          </Button>
+        </Box>
+      </Box>
+    </>
+  );
+});
+
+// observable class
+class GeneralConfigImpl implements GeneralConfig {
+  @IsPositive()
+  @Expose()
+  robotWidth: number = 12;
+  @IsPositive()
+  @Expose()
+  robotHeight: number = 12;
+  @IsBoolean()
+  @Expose()
+  robotIsHolonomic: boolean = false;
+  @IsBoolean()
+  @Expose()
+  showRobot: boolean = false;
+  @ValidateNumber(num => num > 0 && num <= 1000) // Don't use IsEnum
+  @Expose()
+  uol: UnitOfLength = UnitOfLength.Inch;
+  @IsPositive()
+  @Expose()
+  pointDensity: number = 2; // inches
+  @IsPositive()
+  @Expose()
+  controlMagnetDistance: number = 5 / 2.54;
+  @Type(() => FieldImageSignatureAndOrigin)
+  @ValidateNested()
+  @IsObject()
+  @Expose()
+  fieldImage: FieldImageSignatureAndOrigin<FieldImageOriginType> =
+    getDefaultBuiltInFieldImage().getSignatureAndOrigin();
+  @IsString()
+  @MinLength(1)
+  @Expose()
+  chassisName: string = "chassis";
+  @ValidateNumber(num => num >= 0)
+  @Expose()
+  movementTimeout: number = 5000;
+  @IsBoolean()
+  @Expose()
+  relativeCoords: boolean = true;
+  @Exclude()
+  private format_: xVecLibBoomerangFormatV0_1;
+
+  constructor(format: xVecLibBoomerangFormatV0_1) {
+    this.format_ = format;
+    makeAutoObservable(this);
+
+    initGeneralConfig(this);
+  }
+
+  get format() {
+    return this.format_;
+  }
+
+  getConfigPanel() {
+    return <GeneralConfigPanel config={this} />;
+  }
+}
+
+// observable class
+class PathConfigImpl implements PathConfig {
+  @Exclude()
+  speedLimit: EditableNumberRange = {
+    minLimit: { value: 0, label: "" },
+    maxLimit: { value: 0, label: "" },
+    step: 0,
+    from: 0,
+    to: 0
+  };
+  @Exclude()
+  bentRateApplicableRange: EditableNumberRange = {
+    minLimit: { value: 0, label: "" },
+    maxLimit: { value: 0, label: "" },
+    step: 0,
+    from: 0,
+    to: 0
+  };
+  @Exclude()
+  bentRateApplicationDirection = BentRateApplicationDirection.HighToLow;
+
+  @Exclude()
+  readonly format: xVecLibBoomerangFormatV0_1;
+
+  @Exclude()
+  public path!: Path;
+
+  constructor(format: xVecLibBoomerangFormatV0_1) {
+    this.format = format;
+    makeAutoObservable(this);
+  }
+
+  getConfigPanel() {
+    return (
+      <>
+        <Typography>(No setting)</Typography>
+      </>
+    );
+  }
+}
+
+// observable class
+export class xVecLibBoomerangFormatV0_1 implements Format {
+  isInit: boolean = false;
+  uid: string;
+
+  private gc = new GeneralConfigImpl(this);
+
+  constructor() {
+    this.uid = makeId(10);
+    makeAutoObservable(this);
+  }
+
+  createNewInstance(): Format {
+    return new xVecLibBoomerangFormatV0_1();
+  }
+
+  getName(): string {
+    return "xVecLib Boomerang v0.1.0 (inch)";
+  }
+
+  register(app: MainApp): void {
+    if (this.isInit) return;
+    this.isInit = true;
+  }
+
+  unregister(app: MainApp): void {}
+
+  getGeneralConfig(): GeneralConfig {
+    return this.gc;
+  }
+
+  createPath(...segments: Segment[]): Path {
+    return new Path(new PathConfigImpl(this), ...segments);
+  }
+
+  getPathPoints(path: Path): PointCalculationResult {
+    const result = getPathPoints(path, new Quantity(this.gc.pointDensity, this.gc.uol));
+    return result;
+  }
+
+  convertFromFormat(oldFormat: Format, oldPaths: Path[]): Path[] {
+    return convertFormat(this, oldFormat, oldPaths);
+  }
+
+  importPathsFromFile(buffer: ArrayBuffer): Path[] {
+    throw new Error("Unable to import paths from this format, try other formats?");
+  }
+
+  exportCode(): string {
+    const { app } = getAppStores();
+
+    let rtn = "";
+    const gc = app.gc as GeneralConfigImpl;
+
+    const path = app.interestedPath();
+    if (path === undefined) throw new Error("No path to export");
+    if (path.segments.length === 0) throw new Error("No segment to export");
+
+    const uc = new UnitConverter(this.gc.uol, UnitOfLength.Inch);
+    const points = getDiscretePoints(path);
+
+    if (points.length > 0) {
+      const start = points[0];
+      let heading = 0;
+
+      if (start.heading !== undefined && gc.relativeCoords) {
+        heading = fromDegreeToRadian(start.heading);
+      }
+
+      // ALGO: Offsets to convert the absolute coordinates to the relative coordinates LemLib uses
+      const offsets = gc.relativeCoords ? new Vector(start.x, start.y) : new Vector(0, 0);
+      for (const point of points) {
+        // ALGO: Only coordinate points are supported in LemLibOdom format
+        const relative = euclideanRotation(heading, point.subtract(offsets));
+        rtn += `${gc.chassisName}.moveTo(${uc.fromAtoB(relative.x).toUser()}, ${uc.fromAtoB(relative.y).toUser()}, ${
+          gc.movementTimeout
+        });\n`;
+      }
+    }
+
+    return rtn;
+  }
+
+  importPDJDataFromFile(buffer: ArrayBuffer): Record<string, any> | undefined {
+    return importPDJDataFromTextFile(buffer);
+  }
+
+  exportFile(): ArrayBuffer {
+    const { app } = getAppStores();
+
+    let fileContent = this.exportCode();
+
+    fileContent += "\n";
+
+    fileContent += "#PATH.JERRYIO-DATA " + JSON.stringify(app.exportPDJData());
+
+    return new TextEncoder().encode(fileContent);
+  }
+}

--- a/src/format/xVecLibBoomerangFormatV0_1.tsx
+++ b/src/format/xVecLibBoomerangFormatV0_1.tsx
@@ -210,7 +210,7 @@ export class xVecLibBoomerangFormatV0_1 implements Format {
     this.isInit = true;
   }
 
-  unregister(app: MainApp): void { }
+  unregister(app: MainApp): void {}
 
   getGeneralConfig(): GeneralConfig {
     return this.gc;
@@ -245,7 +245,7 @@ export class xVecLibBoomerangFormatV0_1 implements Format {
     if (path.segments.length === 0) throw new Error("No segment to export");
 
     const uc = new UnitConverter(this.gc.uol, UnitOfLength.Inch);
-    const points = (path.segments);
+    const points = path.segments;
     if (points.length > 0) {
       for (const point of points) {
         if (path.segments.indexOf(point) == 0) {
@@ -257,23 +257,25 @@ export class xVecLibBoomerangFormatV0_1 implements Format {
         if (last != null) {
           dis = path.controls.at(0)?.distance(last);
           if (point.isCubic() && dis != null) {
-            let poin = (point.controls[1].distance(point.first)) > (point.controls[2].distance(point.last)) ? point.controls[1] : point.controls[2];
+            let poin =
+              point.controls[1].distance(point.first) > point.controls[2].distance(point.last)
+                ? point.controls[1]
+                : point.controls[2];
             if (path.segments.indexOf(point) == path.segments.length - 1) {
-              pnt = (((point.first.x - poin.x)) / (dis * (Math.sin(point.first.heading))));
-
-            }else
-            {
-              pnt = (((point.last.x - poin.x)) / (dis * (Math.sin(point.last.heading))));
-
+              pnt = (point.first.x - poin.x) / (dis * Math.sin(point.first.heading));
+            } else {
+              pnt = (point.last.x - poin.x) / (dis * Math.sin(point.last.heading));
             }
-
           }
         }
-        arr.push([gc.chassisName, uc.fromAtoB(point.last.x).toUser(), uc.fromAtoB(point.last.y).toUser(), point.last.heading, pnt]);
-
-
+        arr.push([
+          gc.chassisName,
+          uc.fromAtoB(point.last.x).toUser(),
+          uc.fromAtoB(point.last.y).toUser(),
+          point.last.heading,
+          pnt
+        ]);
       }
-
     }
     for (const s of arr) {
       rtn += `${s[0]}.moveToBoom( ${s[1]}, ${s[2]}, ${s[3]}, ${s[4]},${gc.movementTimeout / 1000});\n`;


### PR DESCRIPTION
This introduces a new format that generates boomerang code for xVecLib.

![Screenshot_20240509_165921](https://github.com/Jerrylum/path.jerryio/assets/119263049/f4d1226d-cb67-46c9-a021-fc1a6f74b5d8)
Code exported:
robo.set(59, -34);
imu.set_rotation(270);
ou.printCoords();
ou.moveToBoom( -59.924, -50.746, 347.5795700547434, 0.0672986800982153,5);
ou.moveToBoom( -45.96, 36, 90, -0.12368406072104425,5);
